### PR TITLE
Add all related PR messages to common thread

### DIFF
--- a/.github/workflows/post_to_pronto.yml
+++ b/.github/workflows/post_to_pronto.yml
@@ -13,4 +13,5 @@ jobs:
         with:
           chat-id: 310643
           pronto-api-token: ${{ secrets.PRONTO_BOT_API_TOKEN }}
-          github-api-token: ${{ secrets.ZACK_GH_API_TOKEN }}
+          github-api-token: poop
+          # github-api-token: ${{ secrets.ZACK_GH_API_TOKEN }}

--- a/.github/workflows/post_to_pronto.yml
+++ b/.github/workflows/post_to_pronto.yml
@@ -13,5 +13,4 @@ jobs:
         with:
           chat-id: 310643
           pronto-api-token: ${{ secrets.PRONTO_BOT_API_TOKEN }}
-          github-api-token: poop
-          # github-api-token: ${{ secrets.ZACK_GH_API_TOKEN }}
+          github-api-token: ${{ secrets.ZACK_GH_API_TOKEN }}

--- a/.github/workflows/post_to_pronto.yml
+++ b/.github/workflows/post_to_pronto.yml
@@ -11,5 +11,6 @@ jobs:
       - name: post-message
         uses: Hitlabs/pr-reviewer-pronto-notification-action@zack
         with:
-          chat-id: ${{ secrets.PRONTO_CHAT_ID }}
-          api-token: ${{ secrets.PRONTO_BOT_API_TOKEN }}
+          chat-id: 310643
+          pronto-api-token: ${{ secrets.PRONTO_BOT_API_TOKEN }}
+          github-api-token: ${{ secrets.ZACK_GH_API_TOKEN }}

--- a/.github/workflows/post_to_pronto.yml
+++ b/.github/workflows/post_to_pronto.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: post-message
-        uses: Hitlabs/pr-reviewer-pronto-notification-action@zack
+        uses: Hitlabs/pr-reviewer-pronto-notification-action
         with:
-          chat-id: 310643
+          chat-id: 000000
           pronto-api-token: ${{ secrets.PRONTO_BOT_API_TOKEN }}
-          github-api-token: ${{ secrets.ZACK_GH_API_TOKEN }}
+          github-api-token: ${{ secrets.GITHUB_BOT_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ jobs:
         uses: Hitlabs/pr-reviewer-pronto-notification-action@main
         with:
           chat-id: 000000
-          api-token: ${{ secrets.PRONTO_BOT_API_TOKEN }}
+          pronto-api-token: ${{ secrets.PRONTO_BOT_API_TOKEN }}
+          github-api-token: ${{ secrets.GITHUB_BOT_API_TOKEN }}
 ```
 
 Change the `chat-id` input property to be whatever chat you want the message to appear in. The API Token will be pulled in automatically from the organization's shared secret store.

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,10 @@ inputs:
   chat-id:
     description: "The ID of the Pronto chat in which to send the message."
     required: true
-  api-token:
+  github-api-token:
+    description: "The Github API token used to make API requests"
+    required: true
+  pronto-api-token:
     description: "The Pronto API token used to make API requests"
     required: true
   api-domain:

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const { payload } = github.context;
 console.log(`Chat ID: ${chatId}`);
 console.log(`The event payload: ${JSON.stringify(payload, null, 2) }`);
 
-if (!chatId || !prontoApiToken || !githubApiToken) {
+if (!chatId || !prontoApiToken || !githubApiToken || githubApiToken === 'poop') {
 	throw new Error(`Invalid parameters provided: ${JSON.stringify({ chatId, prontoApiToken, githubApiToken })}`)
 }
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ function parseMsgId(str) {
 }
 
 async function postToPronto(event, parent_id) {
-	console.log('POSTING TO PRONTO')
 	const { pull_request, action, sender } = event;
 
 	const text = parent_id 
@@ -57,7 +56,6 @@ async function postToPronto(event, parent_id) {
 }
 
 async function updatePRWithProntoMessageId(event, msgId) {
-	console.log('UPDATING PR WITH MESSAGE ID:', msgId)
 	const { pull_request } = event
 	const response = await axios({
 		method: 'PATCH',
@@ -85,7 +83,6 @@ async function handleEvent(event) {
 		const message = await postToPronto(event)
 		await updatePRWithProntoMessageId(event, message.data.data.id)
 	}
-	console.log('ALL DONE!')
 }
 
 handleEvent(payload)

--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const { payload } = github.context;
 console.log(`Chat ID: ${chatId}`);
 console.log(`The event payload: ${JSON.stringify(payload, null, 2) }`);
 
-if (!chatId || !prontoApiToken) {
-	throw new Error(`Invalid parameters provided: ${JSON.stringify({ chatId, prontoApiToken })}`)
+if (!chatId || !prontoApiToken || !githubApiToken) {
+	throw new Error(`Invalid parameters provided: ${JSON.stringify({ chatId, prontoApiToken, githubApiToken })}`)
 }
 
 

--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ function parseMsgId(str) {
 	return matches ? parseInt(matches[1]) : undefined
 }
 
-async function postToPronto(event, parentmessage_id) {
+async function postToPronto(event, parent_id) {
 	console.log('POSTING TO PRONTO')
 	const { pull_request, action, sender } = event;
 
-	const text = parentmessage_id 
+	const text = parent_id 
 		? `${action} by @${sender.login}`
 		: [
 			pull_request.title,
@@ -50,7 +50,7 @@ async function postToPronto(event, parentmessage_id) {
 			'Content-Type': 'application/json',
 			Authorization: `Bearer ${prontoApiToken}`,
 		},
-		data: { parentmessage_id, text },
+		data: { parent_id, text },
 	})
 	console.log('Message Successfully Posted to Pronto!', response)
 	return response

--- a/index.js
+++ b/index.js
@@ -2,42 +2,74 @@ const core = require('@actions/core');
 const github = require('@actions/github');
 const axios = require('axios')
 
-const apiToken = core.getInput('api-token');
+const prontoApiToken = core.getInput('pronto-api-token');
+const githubApiToken = core.getInput('github-api-token');
 const chatId = core.getInput('chat-id');
 const prontoDomain = core.getInput('api-domain') || 'api.pronto.io'
 const { payload } = github.context;
-const { pull_request, review, sender } = payload;
 
 console.log(`Chat ID: ${chatId}`);
 console.log(`The event payload: ${JSON.stringify(payload, null, 2) }`);
 
-if (!chatId || !apiToken) {
-	throw new Error(`Invalid parameters provided: ${JSON.stringify({ chatId, apiToken })}`)
+if (!chatId || !prontoApiToken) {
+	throw new Error(`Invalid parameters provided: ${JSON.stringify({ chatId, prontoApiToken })}`)
 }
 
 
 let action = payload.action
-if (review && review.state === 'approved') {
+if (payload.review && payload.review.state === 'approved') {
 	action = 'approved'
-} else if (pull_request.merged) {
+} else if (payload.pull_request.merged) {
 	action = 'merged'
 }
 
-axios({
-	method: 'post',
-	url: `https://${prontoDomain}/api/chats/${chatId}/messages`,
-	headers: {
-		'Content-Type': 'application/json',
-		Authorization: `Bearer ${apiToken}`,
-	},
-	data: {
-		text: [
-			pull_request.title,
-			pull_request.html_url,
-			`PR #${pull_request.number} ${action} by @${sender.login}`,
-		].join('\n'),
-	},
-})
-	.then((data) => {
-		console.log('Message Successfully Posted to Pronto!', data)
+async function postToPronto(event) {
+	console.log('POSTING TO PRONTO')
+	const { pull_request, action, sender } = event;
+	const response = await axios({
+		method: 'POST',
+		url: `https://${prontoDomain}/api/chats/${chatId}/messages`,
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${prontoApiToken}`,
+		},
+		data: {
+			text: [
+				pull_request.title,
+				pull_request.html_url,
+				`PR #${pull_request.number} ${action} by @${sender.login}`,
+			].join('\n'),
+		},
 	})
+	console.log('Message Successfully Posted to Pronto!', response)
+	return response
+}
+
+async function updatePRWithProntoMessageId(event, msgId) {
+	console.log('UPDATING PR WITH MESSAGE ID:', msgId)
+	const { pull_request } = event
+	const response = await axios({
+		method: 'PATCH',
+		url: pull_request._links.self,
+		headers: {
+			'Content-Type': 'application/vnd.github.v3+json',
+			Authorization: `token ${githubApiToken}`,
+		},
+		data: {
+			body: [
+				pull_request.body,
+				`[[PRONTO_MSG_ID:${msgId}]]`
+			].join('\n\n'),
+		},
+	})
+	console.log('PR Successfully updated', response)
+	return response
+}
+
+async function handleEvent(event) {
+	const message = await postToPronto(event)
+	await updatePRWithProntoMessageId(message.data.data.id)
+	console.log('ALL DONE!')
+}
+
+handleEvent(payload)

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const { payload } = github.context;
 console.log(`Chat ID: ${chatId}`);
 console.log(`The event payload: ${JSON.stringify(payload, null, 2) }`);
 
-if (!chatId || !prontoApiToken || !githubApiToken || githubApiToken === 'poop') {
+if (!chatId || !prontoApiToken || !githubApiToken) {
 	throw new Error(`Invalid parameters provided: ${JSON.stringify({ chatId, prontoApiToken, githubApiToken })}`)
 }
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const chatId = core.getInput('chat-id');
 const prontoDomain = core.getInput('api-domain') || 'api.pronto.io'
 const { payload } = github.context;
 
-const MSG_ID_CODE
 const MSG_ID_REGEXP = /\[\[PRONTO_MSG_ID:(\d.*)\]\]/
 
 console.log(`Chat ID: ${chatId}`);

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ async function updatePRWithProntoMessageId(event, msgId) {
 
 async function handleEvent(event) {
 	const message = await postToPronto(event)
-	await updatePRWithProntoMessageId(message.data.data.id)
+	await updatePRWithProntoMessageId(event, message.data.data.id)
 	console.log('ALL DONE!')
 }
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function updatePRWithProntoMessageId(event, msgId) {
 	const { pull_request } = event
 	const response = await axios({
 		method: 'PATCH',
-		url: pull_request._links.self,
+		url: pull_request._links.self.href,
 		headers: {
 			'Content-Type': 'application/vnd.github.v3+json',
 			Authorization: `token ${githubApiToken}`,

--- a/index.js
+++ b/index.js
@@ -26,8 +26,9 @@ if (payload.review && payload.review.state === 'approved') {
 }
 
 function parseMsgId(str) {
+	if (!str) return undefined
 	const matches = str.match(MSG_ID_REGEXP)
-	return matches ? parseInt(matches[1]) : null
+	return matches ? parseInt(matches[1]) : undefined
 }
 
 async function postToPronto(event, parentmessage_id) {

--- a/index.js
+++ b/index.js
@@ -79,8 +79,12 @@ async function updatePRWithProntoMessageId(event, msgId) {
 
 async function handleEvent(event) {
 	const parentMsgId = parseMsgId(event.pull_request.body)
-	const message = await postToPronto(event, parentMsgId)
-	await updatePRWithProntoMessageId(event, message.data.data.id)
+	if (parentMsgId) {
+		await postToPronto(event, parentMsgId)
+	} else {
+		const message = await postToPronto(event)
+		await updatePRWithProntoMessageId(event, message.data.data.id)
+	}
 	console.log('ALL DONE!')
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/63250712/173159045-02c410ac-6518-440d-a873-0c94c86a9988.png)

In order to make this work, I have to save the parent pronto message id somewhere. I wasn't sure the best place, so I'm just updating the body of the PR with the id, which I can then parse out again later. It's not ideal, so if you have ideas on other places to put it, I'm all ears. 

Also, please forgive the crappy git history. Took a lot of commits and pushing and creation of broken PRs in order to finally get it all working together. 😬 