### PR TITLE
Bug: fix action verbage

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function parseMsgId(str) {
 }
 
 async function postToPronto(event, parent_id) {
-	const { pull_request, action, sender } = event;
+	const { pull_request, sender } = event;
 
 	const text = parent_id 
 		? `${action} by @${sender.login}`


### PR DESCRIPTION
I had incorrectly pulled in the event action and was therefore not properly using the overwritten action defined above. By removing the payload's action, it now references the overwritten action I originally intended